### PR TITLE
Avoid broken images bug in OS X 10.10.2

### DIFF
--- a/epubQL/GeneratePreviewForURL.m
+++ b/epubQL/GeneratePreviewForURL.m
@@ -74,12 +74,19 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         [theIcon setSize:NSMakeSize(128.0,128.0)];
         iconData = [[theIcon TIFFRepresentation] retain];
     }
-
+#if ATTACHING_IMAGE
     NSMutableDictionary *iconProps=[[[NSMutableDictionary alloc] init] autorelease];
     iconProps[(NSString *)kQLPreviewPropertyMIMETypeKey] = @"image/tiff";
     iconProps[(NSString *)kQLPreviewPropertyAttachmentDataKey] = iconData;
     props[(NSString *)kQLPreviewPropertyAttachmentsKey] = @{ @"icon.tiff": iconProps };
     [theIcon release];
+#else
+    NSString *base64 = [[NSString alloc] initWithData:[iconData base64EncodedDataWithOptions:0]
+                                             encoding:NSUTF8StringEncoding];
+    NSString *image = [NSString stringWithFormat:@"data:image/tiff;base64,%@", base64];
+    [base64 release];
+    [html replaceOccurrencesOfString:@"%image%" withString:image options:NSLiteralSearch range:NSMakeRange(0, [html length])];
+#endif
     [iconData release];
 
     /*

--- a/epubQL/index.html
+++ b/epubQL/index.html
@@ -22,7 +22,7 @@
 
     <div class="clearBelow">
     <div class="image">
-        <img src="cid:icon.tiff" alt="cover image" />
+        <img src="%image%" alt="cover image" />
     </div>
     </div>
       


### PR DESCRIPTION
Something is broken with the cover image - it is attached correctly but in 10.10.2 it is displayed as a broken link. Could be a security feature/sandbox issue with unsigned QL components?

However we can embed all the image data inside the HTML, and that definitely avoids the problem.